### PR TITLE
Loads babel and corrects \ProvidesPackage to remove warnings.

### DIFF
--- a/config/minimal-resume.sty
+++ b/config/minimal-resume.sty
@@ -1,4 +1,4 @@
-\ProvidesPackage{config/resume-ratul}
+\ProvidesPackage{config/minimal-resume}
 
 % margin
 \usepackage[top=1in, bottom=1in, left=1in, right=1in]{geometry}

--- a/minimal-resume.tex
+++ b/minimal-resume.tex
@@ -1,4 +1,5 @@
 \documentclass[10pt]{article}
+\usepackage[english]{babel}
 
 \input{config/minimal-resume-config}
 


### PR DESCRIPTION
Hi Ratul,

I'm a Community TeXpert at Overleaf; John Hammersley passed me your message about your résumé template to add it to the Gallery. I noticed there were a couple of warnings because of a mismatch in the filename for `minimal-resume.sty` and its `\ProvidesPackage`, and also because `babel` wasn't loaded. I've made some small changes to remove these warnings before publishing your template to the Gallery; I thought you'd like to know. :-)
